### PR TITLE
Clarify selection of MAC, elaborate on MAC chaining and path splicing

### DIFF
--- a/draft-dekater-scion-dataplane.md
+++ b/draft-dekater-scion-dataplane.md
@@ -1115,7 +1115,7 @@ Thus, the current MAC is based on the XOR-sum of the truncated MACs of all prece
 
 #### Accumulator Acc - Definition {#def-acc}
 
-The accumulator Acc<sub>i</sub> is an updatable counter introduced in the data plane to avoid overhead caused by MAC-chaining for path authorization. This is achieved by incrementally tracking the XOR-sum of the previous MACs as a separate, updatable accumulator field `Acc`, which is part of the path segment's info field `InfoField` in the packet header (see also [](#inffield)). Routers update this field by adding/subtracting only a single 16-bit value each.
+The accumulator Acc<sub>i</sub> is an updatable counter introduced in the data plane to avoid the overhead caused by MAC-chaining for path authorization. This is achieved by incrementally tracking the XOR-sum of the previous MACs as a separate, updatable accumulator field `Acc`, which is part of the path segment's info field `InfoField` in the packet header (see also [](#inffield)). Routers update this field by adding/subtracting only a single 16-bit value each.
 
 ~~~~
  0                   1                   2                   3

--- a/draft-dekater-scion-dataplane.md
+++ b/draft-dekater-scion-dataplane.md
@@ -1474,8 +1474,8 @@ Finally, the hop field MAC protects the 16-bit aggregation of path segment ident
 
 As the segment identifier and aggregation of preceding MACs is only 16-bits wide, per-chance collision among compatible path segments can occur.
 With typical network sizes and numbers of paths of today, such collisions might occur rarely.
-Successful path splicing access may result in a usable path that violates an ASes path policy, e.g. making a special transit link available to a customer AS that is not billed accordingly, or violate global validity as a spliced path segment could traverses one or multiple links twice.
-A wider security margin against path splicing could be obtained by increasing the width of the segment identifier / `Acc` field, e.g by extending it into the 8-bit reserved field next to it in the info field. Such a change in the protocol would have to be coordinated with all participating entities (control services, routers, end hosts in all ASes).
+Successful path splicing would allow an attacker to briefly use a path that violates an ASes path policy, e.g. making a special transit link available to a customer AS that is not billed accordingly, or violate general path segment validity requirements. In particular, a spliced path segment could traverse one or multiple links twice. However, creating a loop traversing a link an arbitrary number of times would involve multiple path splices and therefore multiple random collisions happening simultaneously, which is exceedingly unlikely.
+A wider security margin against path splicing could be obtained by increasing the width of the segment identifier / `Acc` field, e.g. by extending it into the 8-bit reserved field next to it in the info field.
 
 
 ## On-Path Attacks

--- a/draft-dekater-scion-dataplane.md
+++ b/draft-dekater-scion-dataplane.md
@@ -1138,7 +1138,7 @@ For high-speed packet processing in the **data plane**, computing even cheap ope
 
 When combining path segments to create a path to the destination endpoint, the source endpoint MUST also initialize the value of accumulator field `Acc` for each path segment. The `Acc` field MUST contain the correct XOR-sum of the path segment identifier and preceding hop field MACs expected by the first router that is traversed.
 
-The aggregated 16-bit path segment identifier and preceding MACs prevents the splicing parts of different path segments, unless there is a per-chance collision among compatible path segments in one AS. Path segments are "compatible" for splicing only if they enter the AS from the same ingress interface and have the same origination timestamp. With typical numbers of paths in
+The aggregated 16-bit path segment identifier and preceding MACs prevents the splicing parts of different path segments, unless there is a per-chance collision of the `Acc` value among compatible path segments in on AS. See {{path-splicing}} for more details.
 
 In the following, the computation of the hop field MAC as well as the accumulator field `Acc` is explained.
 

--- a/draft-dekater-scion-dataplane.md
+++ b/draft-dekater-scion-dataplane.md
@@ -71,6 +71,7 @@ normative:
         org: Anapaya Systems
   RFC2474:
   RFC3168:
+  RFC4493:
   RFC5280:
   RFC5880:
   RFC5881:
@@ -115,7 +116,6 @@ informative:
   RFC1122:
   RFC1918:
   RFC2711:
-  RFC4493:
   RFC9217:
   RFC9473:
   SCMP:


### PR DESCRIPTION
Describe AES-CMAC hop field MAC algorithm as the default which MUST be supported.

- Moved the details of  the default mac algorithm to _after_ the explanation of the accumulator field (as this is used in the mac input).
- Fixed the swapped info field/hop field labels in the figure depicting the MAC input.
- Describe requriements on alternative MAC implementations, in particular about requirements for MAC chaining
- Describe path splicing is prevented
- Describe how path splicing can still happen in security considerations



Contributes to https://github.com/scionassociation/scion-cp_I-D/issues/23.
Contributes to https://github.com/scionassociation/scion-dp_I-D/issues/7