### PR TITLE
describe scmp and bfd.

### DIFF
--- a/draft-dekater-scion-dataplane.md
+++ b/draft-dekater-scion-dataplane.md
@@ -549,8 +549,7 @@ Currently, SCION supports three path types:
 
 The `Empty` path type is used to send traffic within an AS. It has no additional fields, i.e., it consumes 0 bytes on the wire.
 
-One use case of the `Empty` path type lies in the context of link-failure detection. To this end, SCION uses the Bidirectional Forwarding Detection (BFD) protocol ({{RFC5880}} and {{RFC5881}}). BFD is a protocol intended to detect faults in the bidirectional path between two forwarding engines, with typically very low latency. It operates independently of media, data protocols, and routing protocols. SCION uses the `Empty` path type, together with `OneHopPath` path type, to bootstrap BFD within SCION. (For more information on the `OneHopPath` path type, see [](#onehop).)
-
+One use case of the `Empty` path type lies in the context of [link-failure detection](#scion-bfd).
 
 #### SCION Path Type {#scion-path-type}
 
@@ -1415,7 +1414,6 @@ This section describes the steps that a SCION egress border router MUST perform 
 
 **Note:** For more information on the path meta header, see [](#PathMetaHdr).
 
-
 #### Effects of Clock Inaccuracy
 
 A PCB originated by a given control service is used to construct data plane paths. Specifically, the timestamp in the Info Field and the expiry time of hop fields are used for hop field MAC computation, see [](#hf-mac-calc), which is used to validate paths at each on-path SCION router. A segment's originating control service and the routers that the segment refers to all have different clocks. Their differences affect the validation process:
@@ -1429,6 +1427,250 @@ In comparison to these time scales, clock offsets in the order of minutes are im
 
 Each administrator of SCION control services and routers is responsible for maintaining sufficient clock accuracy. No particular method is assumed by this specification.
 
+# Failure To Forward
+
+## Link Failure Detection - BFD {#scion-bfd}
+
+One of the reasons not to forward a packet is the failure of the link through which the packet needs to egress. Whether such failures are detectable upon sending depends on the underlay protocol being used. In the case of UDP/IP, it is common for failures to go undetected. To detect link failures more reliably, SCION uses the Bidirectional Forwarding Detection (BFD) protocol ({{RFC5880}} and {{RFC5881}}). BFD is a protocol intended to detect faults in the bidirectional path between two forwarding engines, with typically very low latency. It operates independently of media, data protocols, and routing protocols.
+
+A SCION router monitor the links at each of its external interfaces by exchanging BFD messages with its peer. A SCION router monitors its connectivity with other routers in the same AS by exchanging BFD messages with them. A SCION BFD message is a SCION packet with a `NextHdr` value of `203` (`BFD/SCION`) and a path type of either `00` (`Empty` - used on internal links) or `2` (`OneHopPath` - used on inter-as links). The BFD header itself is a BFD Control Header as described in {{RFC5880}}.
+
+More information is available on one-hop and empty paths in [](#onehop) and [](#empty).
+
+The protocol between peers is as descibed in {{RFC5880}}. To summarize: if a node does not receive a BFD message from its peer at some regular interval, it considers the link to be down (in both directions) until messages are received again.
+
+A SCION router should accept BFD connections from its peers and SHOULD establish BFD connections to its peers. While a link is considered to be down, a SCION router should drop packets that must egress via that link. When a SCION router drops a packet due to link down, it SHOULD send a corresponding [SCMP notification](#scmp-notification) to the originator.
+
+## Notification - SCMP {#scmp-notification}
+
+If a failure to forward a packet is the result of a local condition, the path used by the packet is unusable. As a result, the originator cannot communicate with the recipient until the fault is repaired, the path expires, or a different path is used. SCION is designed so that a router cannot change the path followed by a packet. Only the originating endpoint can chose a different path. Therefore, to enable fast recovery, a router SHOULD notify the originator if the packet is dropped due to a local, non-transient, fault.
+
+For that purpose SCION defines the Scion Control Message Protocol (SCMP). This document specifies only messages RECOMMENDED for the purpose of path recovery. An extended specification, still a work in progress, can be found in {{SCMP}}.
+
+Sending an SCMP error notification is never mandatory. To reduce exposure to denial-of-service attacks, a SCION router SHOULD restrict the amount of work done when dropping a packet. In most cases the packet SHOULD be dropped without performing any additional work. Rate-limiting the preparation and sending of recommended SCMP notifications (especially identical ones) is good practice. Rate limit policies are up to each AS' administrator.
+
+### General Format
+
+Every SCMP message is preceded by a SCION header, and zero or more SCION extension headers. The SCMP header is identified by a `NextHdr` value of `202` in the immediately preceding header.
+
+The messages have the following general format:
+
+~~~~
+
+     0                   1                   2                   3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |     Type      |     Code      |           Checksum            |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                       Type-dependent Block                    |
+    +                                                               +
+    |                         (variable length)                     |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+~~~~
+{: #figure-21 title="SCMP message format"}
+
+*Type* indicates the type of SCMP message. Its value determines the format of the info and data block.
+
+*Code* provides additional granularity to the SCMP type.
+
+*Checksum* is used to detect data corruption.
+
+*InfoBlock* is an optional field of variable length. The format is dependent on the message type.
+
+*DataBlock* is an optional field of variable length. The format is dependent on the message type.
+
+### Message Types
+
+SCMP messages are grouped into two classes: error messages and informational messages. Error messages are identified by a zero in the high-order bit of the type value. I.e., error messages have a type value in the range of 0-127. Informational messages have type values in the range of 128-255.
+
+This specification defines the message formats for the following SCMP messages:
+
+**SCMP error messages**:
+
+|Type | Meaning													  |
+|-----+-----------------------------------------------------------|
+|1    | Reserved for future use									  |
+|2    | [Packet Too Big](#packet-too-big)						  |
+|3    | Reserved for future use									  |
+|4    | Reserved for future use									  |
+|5    | [External Interface Down](#external-interface-down)		  |
+|6    | [Internal Connectivity Down](#internal-connectivity-down) |
+|	  |															  |
+|100  | Private Experimentation									  |
+|101  | Private Experimentation									  |
+|	  |															  |
+|127  | Reserved for expansion of SCMP error messages			  |
+{: title="type values"}
+
+**SCMP informational messages**:
+
+| Type | Meaning												  |
+|------+----------------------------------------------------------|
+| 128  | Reserved for future use								  |
+| 129  | Reserved for future use								  |
+| 130  | Reserved for future use								  |
+| 131  | Reserved for future use								  |
+| 200  | Private Experimentation								  |
+| 201  | Private Experimentation								  |
+|      |														  |
+| 255  | Reserved for expansion of SCMP informational messages	  |
+{: title="type values"}
+
+Type values 100, 101, 200, and 201 are reserved for private experimentation.
+They are not intended for general use. Any wide-scale and/or uncontrolled usage
+should obtain a real allocation.
+
+Type values 127 and 255 are reserved for future expansion of in case of a
+shortage of type values.
+
+### Checksum Calculation
+
+The checksum is the 16-bit one's complement of the one's complement sum of the
+entire SCMP message, starting with the SCMP message type field, and prepended
+with a "pseudo-header" consisting of the SCION address header and the layer-4
+protocol type as defined in [](#pseudo).
+
+### Processing Rules
+
+Implementations MUST respect the following rules when processing SCMP messages:
+
+   - If an SCMP error message of unknown type is received at its destination, it MUST be passed to the upper-layer process that originated the packet that caused the error, if it can be identified.
+   - If an SCMP informational message of unknown type is received, it MUST be silently dropped.
+   - Every SCMP error message MUST include as much of the offending SCION packet as possible without making the error message packet - including the SCION header and all extension headers - exceed **1232 bytes**.
+   - In case the implementation is required to pass an SCMP error message to the upper-layer process, the upper-layer protocol type is extracted from the original packet in the body of the SCMP error message and used to select the appropriate process to handle the error. In case the upper-layer protocol type cannot be extracted from the SCMP error message body, the SCMP message MUST be silently dropped.
+   - An SCMP error message MUST NOT be originated in response of receiving any of the following:
+     - An SCMP error message.
+     - A packet whose source address does not uniquely identify a single node. E.g., an IPv4 or IPv6 multicast address.
+
+### Error Messages
+
+#### Packet Too Big {#packet-too-big}
+
+~~~~
+
+     0                   1                   2                   3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |     Type      |     Code      |          Checksum             |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |            reserved           |             MTU               |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                As much of the offending packet                |
+    +              as possible without the SCMP packet              +
+    |                    exceeding 1232 bytes.                      |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+~~~~
+{:figure-24 title="packet-too-big}
+
+| SCMP Fields  |                                                               |
+|--------------+---------------------------------------------------------------|
+| Type         | 2                                                             |
+| Code         | 0                                                             |
+| MTU          | The Maximum Transmission Unit of the next-hop link.           |
+{: title="field values"}
+
+A **Packet Too Big** message SHOULD be originated by a router in response to a
+packet that cannot be forwarded because the packet is larger than the MTU of the
+outgoing link. The MTU value is set to the maximum size a SCION packet can have
+to still fit on the next-hop link, as the sender has no knowledge of the
+underlay.
+
+#### External Interface Down {#external-interface-down}
+
+~~~~
+
+     0                   1                   2                   3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |     Type      |     Code      |          Checksum             |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |              ISD              |                               |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+         AS                    +
+    |                                                               |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                                                               |
+    +                        Interface ID                           +
+    |                                                               |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                As much of the offending packet                |
+    +              as possible without the SCMP packet              +
+    |                    exceeding 1232 bytes.                      |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+~~~~
+{:#figure-22 title="External-interface-down-format"}
+
+| SCMP Fields  |                                                               |
+|--------------+---------------------------------------------------------------|
+| Type         | 5                                                             |
+| Code         | 0                                                             |
+| ISD          | The 16-bit ISD identifier of the SCMP originator              |
+| AS           | The 48-bit AS identifier of the SCMP originator               |
+| Interface ID | The interface ID of the external link with connectivity issue.|
+{: title="field values"}
+
+A **External Interface Down** message SHOULD be originated by a router in response
+to a packet that cannot be forwarded because the link to an external AS is broken.
+The ISD and AS identifier are set to the ISD-AS of the originating router.
+The interface ID identifies the link of the originating AS that is down.
+
+Recipients can use this information to route around broken data-plane links.
+
+#### Internal Connectivity Down {#internal-connectivity-down}
+
+~~~~
+
+     0                   1                   2                   3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |     Type      |     Code      |          Checksum             |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |              ISD              |                               |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+         AS                    +
+    |                                                               |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                                                               |
+    +                   Ingress Interface ID                        +
+    |                                                               |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                                                               |
+    +                   Egress Interface ID                         +
+    |                                                               |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                As much of the offending packet                |
+    +              as possible without the SCMP packet              +
+    |                    exceeding 1232 bytes.                      |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+~~~~
+{:figure-23 title="internal-connectivity-down-format"}
+
+| SCMP Fields  |                                                               |
+|--------------+---------------------------------------------------------------|
+| Type         | 6                                                             |
+| Code         | 0                                                             |
+| ISD          | The 16-bit ISD identifier of the SCMP originator              |
+| AS           | The 48-bit AS identifier of the SCMP originator               |
+| Ingress ID   | The interface ID of the ingress link.                         |
+| Egress ID    | The interface ID of the egress link.                          |
+{: title="field values"}
+
+A **Internal Connectivity Down** message SHOULD be originated by a router in
+response to a packet that cannot be forwarded inside the AS because because the
+connectivity between the ingress and egress routers is broken. The ISD and AS
+identifier are set to the ISD-AS of the originating router. The ingress
+interface ID identifies the interface on which the packet enters the AS. The
+egress interface ID identifies the interface on which the packet is destined to
+leave the AS, but the connection is broken to.
+
+Recipients can use this information to route around broken data-plane inside an
+AS.
+
+### Authentication
+
+Authentication of SCMP packets is not specified. In a context where endpoints may depend on SCMP messages (at least [External Interface Down](#external-interface-down) and [Internal Connectivity Down](#internal-connectivity-down)) for reliable operations, this is recognized as a problem and is being addressed.
 
 # Security Considerations
 
@@ -1537,8 +1779,6 @@ This appendix lists the assigned SCION protocol numbers.
 SCION attempts to take the IANA's assigned Internet protocol numbers into consideration. Widely employed protocols have the same protocol number as the one assigned by IANA. SCION specific protocol numbers start at 200.
 
 The protocol numbers are used in the SCION header to identify the upper layer protocol.
-
-SCMP refers to the SCION Control Message Protocol, used for diagnostics and error messages. Support for this protocol is OPTIONAL. A work-in-progress specification is available at: {{SCMP}}.
 
 ## Assignment
 {:numbered="false"}

--- a/draft-dekater-scion-dataplane.md
+++ b/draft-dekater-scion-dataplane.md
@@ -1488,33 +1488,33 @@ This specification defines the message formats for the following SCMP messages:
 
 **SCMP error messages**:
 
-|Type | Meaning													  |
+|Type | Meaning                                                   |
 |-----+-----------------------------------------------------------|
-|1    | Reserved for future use									  |
-|2    | [Packet Too Big](#packet-too-big)						  |
-|3    | Reserved for future use									  |
-|4    | Reserved for future use									  |
-|5    | [External Interface Down](#external-interface-down)		  |
+|1    | Reserved for future use                                   |
+|2    | [Packet Too Big](#packet-too-big)                         |
+|3    | Reserved for future use                                   |
+|4    | Reserved for future use                                   |
+|5    | [External Interface Down](#external-interface-down)       |
 |6    | [Internal Connectivity Down](#internal-connectivity-down) |
-|	  |															  |
-|100  | Private Experimentation									  |
-|101  | Private Experimentation									  |
-|	  |															  |
-|127  | Reserved for expansion of SCMP error messages			  |
+|     |                                                           |
+|100  | Private Experimentation                                   |
+|101  | Private Experimentation                                   |
+|     |                                                           |
+|127  | Reserved for expansion of SCMP error messages             |
 {: title="type values"}
 
 **SCMP informational messages**:
 
-| Type | Meaning												  |
+| Type | Meaning                                                  |
 |------+----------------------------------------------------------|
-| 128  | Reserved for future use								  |
-| 129  | Reserved for future use								  |
-| 130  | Reserved for future use								  |
-| 131  | Reserved for future use								  |
-| 200  | Private Experimentation								  |
-| 201  | Private Experimentation								  |
-|      |														  |
-| 255  | Reserved for expansion of SCMP informational messages	  |
+| 128  | Reserved for future use                                  |
+| 129  | Reserved for future use                                  |
+| 130  | Reserved for future use                                  |
+| 131  | Reserved for future use                                  |
+| 200  | Private Experimentation                                  |
+| 201  | Private Experimentation                                  |
+|      |                                                          |
+| 255  | Reserved for expansion of SCMP informational messages    |
 {: title="type values"}
 
 Type values 100, 101, 200, and 201 are reserved for private experimentation.
@@ -1564,11 +1564,11 @@ Implementations MUST respect the following rules when processing SCMP messages:
 ~~~~
 {:figure-24 title="packet-too-big}
 
-| SCMP Fields  |                                                               |
-|--------------+---------------------------------------------------------------|
-| Type         | 2                                                             |
-| Code         | 0                                                             |
-| MTU          | The Maximum Transmission Unit of the next-hop link.           |
+| SCMP Fields  |                                                     |
+|--------------+-----------------------------------------------------|
+| Type         | 2                                                   |
+| Code         | 0                                                   |
+| MTU          | The Maximum Transmission Unit of the next-hop link. |
 {: title="field values"}
 
 A **Packet Too Big** message SHOULD be originated by a router in response to a


### PR DESCRIPTION
I added an entire section dedicated to link failures, with a subsection for detection (BFD) and a subsection for notification (SCMP).

For SCMP: I copied the SCMP description in our manuals but reduced it to the 3 message types that we need for path recovery. I included the message too big because we know we'll have to talk about that too. Then I described what the router does with them in my own words.

For BFD, I created a dedicated subsection and moved and expanded what little text we had, I have not described the bootstrapping because I thought it'd be too much, but I think it might be ok to add it. Let me know what you think.

Cleaned-up mentions of those here and there to turn them into references to the above.

Fixes #36 
Fixes #37 
Fixes #41 