### PR TITLE
Removed SIG protocol description

### DIFF
--- a/draft-dekater-scion-dataplane.md
+++ b/draft-dekater-scion-dataplane.md
@@ -208,7 +208,7 @@ Note (to be removed before publication): this document, together with the other 
 
 **Egress/Ingress**: refers to the direction of travel. In SCION, path construction with beaconing happens in one direction, while actual traffic might follow the opposite direction. This document clarifies on a case-by-case basis whether 'egress' or 'ingress' refers to the direction of travel of the SCION packet or to the direction of beaconing.
 
-**Endpoint**: An endpoint is the start or the end of a SCION path. For example, an endpoint can be a host as defined in {{RFC1122}} or a [SCION IP gateway](#sig) bridging a SCION and an IP domain. This definition is based on the definition in {{RFC9473}}.
+**Endpoint**: An endpoint is the start or the end of a SCION path, as defined in {{RFC9473}}.
 
 **Forwarding Key**: A forwarding key is a symmetric key that is shared between the control service (control plane) and the routers (data plane) of an AS. It is used to authenticate Hop Fields in the end-to-end SCION path. The forwarding key is an AS-local secret and is not shared with other ASes.
 


### PR DESCRIPTION
Now contains brief SIG description and note that IP tunnelling is out-of-scope of the draft. 