### PR TITLE
add POSIX normative reference to clarify time zone and leap seconds

### DIFF
--- a/draft-dekater-scion-dataplane.md
+++ b/draft-dekater-scion-dataplane.md
@@ -1594,6 +1594,7 @@ Changes made to drafts since ISE submission. This section is to be removed befor
 {:numbered="false"}
 
 - Add normative reference to POSIX time and clarify timestamp behavior at wraparound
+- Clarify distinction between SCION ASes and BGP ASes through the text
 
 ## draft-dekater-scion-dataplane-09
 {:numbered="false"}


### PR DESCRIPTION
Resolves #127 

[Diff with main](https://author-tools.ietf.org/api/iddiff?url_1=https://scionassociation.github.io/scion-dp_I-D/draft-dekater-scion-dataplane.txt&url_2=https://scionassociation.github.io/scion-dp_I-D/time_clarification/draft-dekater-scion-dataplane.txt)